### PR TITLE
Made the stats section responsive for mobiles

### DIFF
--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -165,8 +165,14 @@
   .mission-vision-card{
     max-height: 400px;
   }
+
+  .grid-container{
+    flex-wrap: wrap;
+    justify-content: center;
+  }
   
   .stat-card {
+    max-width: 100%;
     margin-bottom: 1.5rem;
   }
 


### PR DESCRIPTION
Issue No. :314

Closes #314 

I have made the stats section responsive for mobile version.

OUTPUT:
![Capturedfd](https://github.com/user-attachments/assets/97029c0f-1be9-4432-a3ec-058c49600c7c)


@GAVINESHWAR Kindly review the PR at the earliest
# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md` if its a new page/tech stack
- [x] I have gone through the  `contributing.md` file before contributing


- [x] I'm a GSSOC-EXT contributor
- [x] I'm a HACKTOBERFEST contributor
       
